### PR TITLE
Unlink from redis_auth

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,10 +37,8 @@ services:
      - "FACEBOOK_APP_ID=1234567890"
      - "FACEBOOK_APP_SECRET="
      - "NODE_ENV="
-     - "REDIS_AUTH_PORT_6379_TCP_ADDR=authredis"
      - "CENTRAL_USERMETA_PORT_8000_TCP_ADDR=centralusermeta"
      - "LOCAL_USERMETA_PORT_8000_TCP_ADDR=localusermeta"
-     - "LOCAL_USERMETA_PORT_8000_TCP_PORT=8000"
      - "DIRECTORY_PORT_8000_TCP_ADDR=directory"
     ports:
      - "8001:8000"
@@ -82,7 +80,7 @@ services:
      - "NODE_ENV="
 
   directory:
-    image: ganomede/directory:v0.2.0
+    image: ganomede/directory:v0.3.0
     depends_on:
       - directorysync
     ports:
@@ -95,7 +93,7 @@ services:
 
   # will just sync the database
   directorysync:
-    image: ganomede/directory:v0.2.0
+    image: ganomede/directory:v0.3.0
     depends_on:
      - directorycouch
      - authredis

--- a/package.json
+++ b/package.json
@@ -8,17 +8,15 @@
     "node": ">=6"
   },
   "scripts": {
-    "start": "./node_modules/.bin/forever start index.js",
-    "stop": "./node_modules/.bin/forever stop index.js",
-    "test": "./run_tests.sh",
-    "testw": "./run_tests.sh --watch tests",
-    "lint": "eslint src/ tests/ index.js config.js && coffeelint --quiet src tests"
+    "start": "node index.js",
+    "test": "SKIP_LINT=1 ./run_tests.sh",
+    "testw": "SKIP_LINT=1 ./run_tests.sh --watch tests",
+    "lint": "SKIP_MOCHA=1 ./run_tests.sh"
   },
   "author": "Jean-Christophe Hoelt <hoelt@fovea.cc>",
   "license": "GPL",
   "dependencies": {
     "async": "^2.0.1",
-    "authdb": "^0.3.0",
     "bunyan": "^1.2.3",
     "coffee-script": "^1.8.0",
     "coffeelint": "^1.6.1",
@@ -27,6 +25,7 @@
     "fakeredis": "^1.0.3",
     "fbgraph": "^1.0.0",
     "forever": "^0.15.3",
+    "ganomede-directory": "^0.3.0",
     "ganomede-events": "^1.1.0",
     "ganomede-helpers": "^1.0.6",
     "ganomede-tagizer": "^1.0.0",

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -11,12 +11,15 @@ if [ -z "$SKIP_LINT" ]; then
     echo "coffeelint..."
     ./node_modules/.bin/coffeelint -q src tests
 fi
-BUNYAN_LEVEL=1000
-MOCHA_ARGS="--bail --compilers coffee:coffee-script/register"
-if [ -z "$1" ]; then
-    MORE_MOCHA_ARGS=tests/**/test-*.coffee
+
+if [ -z "$SKIP_MOCHA" ]; then
+    BUNYAN_LEVEL=1000
+    MOCHA_ARGS="--bail --compilers coffee:coffee-script/register"
+    if [ -z "$1" ]; then
+        MORE_MOCHA_ARGS=tests/**/test-*.coffee
+    fi
+    echo "mocha..."
+    ./node_modules/.bin/mocha ${MOCHA_ARGS} ${MORE_MOCHA_ARGS} "$@"
+    # BUNYAN="./node_modules/.bin/bunyan -l ${BUNYAN_LEVEL}"
+    # ./node_modules/.bin/mocha ${MOCHA_ARGS} | ${BUNYAN}
 fi
-echo "mocha..."
-./node_modules/.bin/mocha ${MOCHA_ARGS} ${MORE_MOCHA_ARGS} "$@"
-# BUNYAN="./node_modules/.bin/bunyan -l ${BUNYAN_LEVEL}"
-# ./node_modules/.bin/mocha ${MOCHA_ARGS} | ${BUNYAN}


### PR DESCRIPTION
- Create a authdb compatible client based upon directoryClient (so we don't have to change the rest of the code).
 - Make it part of ganomede-directory's client library so everyone gets access to it:

```js
require('ganomede-directory').createAuthClient({host,port,protocol,apiSecret});
```