### PR TITLE
fix secret leak

### DIFF
--- a/src/bans.coffee
+++ b/src/bans.coffee
@@ -21,7 +21,6 @@ class Bans
       if (err)
         return cb(err)
       info = new BanInfo(username, reply)
-      require('./log').warn('Bans#get()', {username, reply, info})
       cb(null, info)
 
   # callback(err)

--- a/src/bans.coffee
+++ b/src/bans.coffee
@@ -15,20 +15,23 @@ class Bans
   #   return [@prefix, parts...].join(':')
 
   # callback(err, BanInfo instance)
-  get: (username, cb) ->
-    @usermetaClient.get username, @prefix, (err, reply) ->
+  get: (params, cb) ->
+    {username} = params
+    @usermetaClient.get params, @prefix, (err, reply) ->
       if (err)
         return cb(err)
-      cb(null, new BanInfo(username, reply))
+      info = new BanInfo(username, reply)
+      require('./log').warn('Bans#get()', {username, reply, info})
+      cb(null, info)
 
   # callback(err)
-  ban: (username, cb) ->
-    @usermetaClient.set username, @prefix,
+  ban: (params, cb) ->
+    @usermetaClient.set params, @prefix,
       String(Date.now()), wrapCallback(cb)
 
   # callback(err)
-  unban: (username, cb) ->
-    @usermetaClient.set username, @prefix,
+  unban: (params, cb) ->
+    @usermetaClient.set params, @prefix,
       null, wrapCallback(cb)
 
 module.exports = {Bans, BanInfo}

--- a/tests/test-bans.coffee
+++ b/tests/test-bans.coffee
@@ -50,46 +50,46 @@ describe 'Bans', () ->
     bans = new Bans({usermetaClient})
 
   started = Date.now()
-  usernames = {
-    banned: 'bad-person',
-    notBanned: 'good-citizen'
+  params = {
+    banned: {username: 'bad-person', apiSecret: 'wever'},
+    notBanned: {username: 'good-citizen', apiSecret: 'wever'}
   }
 
   describe '#ban()', () ->
     it 'adds bans', (done) ->
-      bans.ban usernames.banned, (err) ->
+      bans.ban params.banned, (err) ->
         expect(err).to.be.null
         td.verify usermetaClient.set(
-          usernames.banned, '$banned', td.matchers.anything(),
+          params.banned, '$banned', td.matchers.anything(),
           td.callback)
         done()
 
   describe '#get()', () ->
     it 'returns BanInfo instances', (done) ->
-      bans.get usernames.banned, (err, info) ->
+      bans.get params.banned.username, (err, info) ->
         expect(err).to.be.null
         expect(info).to.be.instanceof(BanInfo)
         done()
 
     it.skip 'results are correct', (done) ->
       async.mapValues(
-        usernames,
-        (username, key, cb) -> bans.get(username, cb),
+        params,
+        (username, key, cb) -> bans.get(params.username, cb),
         (err, infos) ->
           expect(err).to.be.null
-          expect(infos.banned.username).to.equal(usernames.banned)
+          expect(infos.banned.username).to.equal(params.banned.username)
           expect(infos.banned.exists).to.be.true
-          expect(infos.notBanned.username).to.equal(usernames.notBanned)
+          expect(infos.notBanned.username).to.equal(params.notBanned.username)
           expect(infos.notBanned.exists).to.be.false
           done()
       )
 
   describe.skip '#unban()', () ->
     it 'removes existing bans', (done) ->
-      bans.unban usernames.banned, (err) ->
+      bans.unban params.banned.username, (err) ->
         expect(err).to.be.null
 
-        client.exists "bans:#{usernames.banned}", (err, reply) ->
+        client.exists "bans:#{params.banned.username}", (err, reply) ->
           expect(err).to.be.null
           expect(reply).to.be.equal(0)
           done()


### PR DESCRIPTION
So. Old `Bans` were using redis with `username:String -> timestamp`. New ones use usermeta, so `username:String -> JSON`. Except usermeta also needs secret, so its API was `usermeta.get({apiSecret, username}, …)`.

That all was fine except Bans was calling usermeta, so we were passing args under usermeta signature, but Bans was expecting strings. And it used passed in username for filling out JSON, and since it was `{secret, username}` and not `username`, well… type checking amirite? I think diff will explain it better than me :)