### PR TITLE
fix/unban

### DIFF
--- a/src/bans.coffee
+++ b/src/bans.coffee
@@ -10,7 +10,6 @@ class BanInfo
     @username = username
     @exists = exists
     @createdAt = createdAt
-    console.log(this)
 
 # callback(err, stuff...) => callback(err)
 wrapCallback = (cb) ->

--- a/src/bans.coffee
+++ b/src/bans.coffee
@@ -1,7 +1,16 @@
+parseTimestampString = (value) ->
+  str = String(value)
+  int = parseInt(str, 10)
+  okay = isFinite(int) && /\d{13}/.test(str) # 13 digits should cover it :)
+  return {okay, value: if okay then int else 0}
+
 class BanInfo
-  constructor: (@username, creationTimestamp) ->
-    @createdAt = parseInt(String(creationTimestamp), 10) || 0
-    @exists = !!@createdAt
+  constructor: (username, creationTimestamp) ->
+    {okay: exists, value: createdAt} = parseTimestampString(creationTimestamp)
+    @username = username
+    @exists = exists
+    @createdAt = createdAt
+    console.log(this)
 
 # callback(err, stuff...) => callback(err)
 wrapCallback = (cb) ->
@@ -30,7 +39,6 @@ class Bans
 
   # callback(err)
   unban: (params, cb) ->
-    @usermetaClient.set params, @prefix,
-      null, wrapCallback(cb)
+    @usermetaClient.set params, @prefix, '<no>', wrapCallback(cb)
 
 module.exports = {Bans, BanInfo}

--- a/tests/test-bans.coffee
+++ b/tests/test-bans.coffee
@@ -7,29 +7,33 @@ describe 'BanInfo', () ->
   username = 'someone'
 
   describe 'Existing ban', () ->
-    now = Date.now()
-    ban = new BanInfo(username, now)
+    it 'timestamps means ban exists', () ->
+      info = new BanInfo(username, Date.now())
+      expect(info.exists).to.be.true
 
-    it 'contains #username', () ->
-      expect(ban.username).to.equal(username)
-
-    it '#createdAt has creation timestamp', () ->
-      expect(ban.createdAt).to.equal(now)
-
-    it '#exists is true', () ->
-      expect(ban.exists).to.be.true
+    it 'existent bans have correct props', () ->
+      now = Date.now()
+      expect(new BanInfo(username, String(now))).to.eql({
+        username,
+        exists: true,
+        createdAt: now
+      })
 
   describe 'Non-existing ban', () ->
-    ban = new BanInfo(username, null)
+    it '<null> means no ban', () ->
+      expect(new BanInfo(username, null).exists).to.be.false
 
-    it 'contains #username', () ->
-      expect(ban.username).to.equal(username)
+    it 'non-timestamp string means no ban', () ->
+      expect(new BanInfo(username, '').exists).to.be.false
+      expect(new BanInfo(username, '<no>').exists).to.be.false
+      expect(new BanInfo(username, '123').exists).to.be.false
 
-    it '#createdAt is null', () ->
-      expect(ban.createdAt).to.equal(0)
-
-    it '#exists returns false', () ->
-      expect(ban.exists).to.be.false
+    it 'non existent ban has correct fields', () ->
+      expect(new BanInfo(username, null)).to.eql({
+        username,
+        createdAt: 0,
+        exists: false
+      })
 
 describe 'Bans', () ->
 

--- a/tests/test-users-api.coffee
+++ b/tests/test-users-api.coffee
@@ -266,10 +266,10 @@ describe 'users-api', ->
     describe '/banned-users Banning Users', () ->
 
       username = data.createAccount.valid.username
-      BAN_TIMESTAMP=123
+      BAN_TIMESTAMP=Date.now()
       beforeEach ->
         td.when(test.bans.get {username,apiSecret})
-          .thenCallback null, new BanInfo(username, ''+BAN_TIMESTAMP)
+          .thenCallback null, new BanInfo(username, String(BAN_TIMESTAMP))
 
       describe 'POST', () ->
 


### PR DESCRIPTION
Unbanning was trying to set meta value `$banned` to `null` (JS null, not string). But usermeta service only  accepts strings (and no deletion). So:

  - changed #unban so it sets a key to `'<no>'`;
  - only users where `$banned` key is valid JS timestamp (13 digits string) are considered banned.