### PR TITLE
add virtual usermeta to /me 

### DIFF
--- a/src/api/api-me.ts
+++ b/src/api/api-me.ts
@@ -111,16 +111,18 @@ export function addRoutes(options: ApiMeOptions) {
             params.name = account.name;
             params.email = account.email;
         }
-        async.mapValues<1, string | null>({
-            'country': 1,
-            'yearofbirth': 1,
-            '$chatdisabled': 1,
-        }, function(_one, key, callback) {
-            options.rootUsermetaClient.get(params, key, callback);
-        }, function(err, results) {
-            if (err) {
-                req.log.warn({err}, 'Failed to fetch metadata');
+        const keys: string[] = ['country', 'yearofbirth', '$chatdisabled', '$blocked', 'location',
+            'singleplayerstats', 'name'];
+        options.rootUsermetaClient.getBulkForUser(params, keys, (err2, reply2) => {
+            if (err2) {
+                req.log.warn({ err2 }, 'Failed to fetch metadata');
             }
+            const results = reply2?.reduce((acc, usemeta) => {
+                return {
+                    [usemeta.key]: usemeta.value,
+                    ...acc
+                };
+            }, {});
             req.params._store.account.metadata = results;
             return next();
         });

--- a/src/usermeta.ts
+++ b/src/usermeta.ts
@@ -45,7 +45,7 @@ export type KeyValue = {
 export type UsernameKeyValue = {
   username: string,
   key: string,
-  value?: string,
+  value: string | null,
 };
 
 export type BuildTask = AsyncFunction<UsernameKeyValue[], Error | null>;
@@ -73,12 +73,12 @@ export abstract class BulkedUsermetaClient {
         if (err) {
           // in bulk mode, errors are just logged
           log.warn({ req_id: pparams.req_id }, 'Failed to fetch protected metadata ' + key);
-          return cb2(null, { username: pparams.username, key });
+          return cb2(null, { username: pparams.username, key, value: null });
         }
         cb2(err, {
           username: pparams.username,
           key,
-          value: typeof reply === 'string' ? reply : undefined
+          value: typeof reply === 'string' ? reply : null
         });
       }));
 
@@ -450,7 +450,7 @@ class DirectoryAliasesPublic extends BulkedUsermetaClient implements SimpleUserm
         return { username, key, value: '' };
       if (typeof value === "string")
         return { username, key, value };
-      return { username, key };
+      return { username, key, value: null };
     });
 
     //check if there are undefined values.

--- a/tests/test-bulk-usermeta-endpoints.ts
+++ b/tests/test-bulk-usermeta-endpoints.ts
@@ -65,7 +65,7 @@ const BY_TAGS = Object.values(accounts).reduce((acc, value) => {
 const ukv = (username, key) => ({
     username,
     key,
-    value: username !== 'n0b0dy' ? `${username}-${key}` : undefined
+    value: username !== 'n0b0dy' ? `${username}-${key}` : null
 });
 
 let nextPort = 31009;
@@ -516,7 +516,7 @@ describe('GET /multi/metadata/:userIds/:keys', () => {
             .end((err, res) => {
                 expect(err, 'request error').to.be.null;
                 expect(res?.body).to.eql([
-                    { username: 'alice', key: 'email' }
+                    { username: 'alice', key: 'email', value: null }
                 ]);
                 done();
             });
@@ -594,14 +594,14 @@ describe('GET /multi/metadata/:userIds/:keys', () => {
                     { username: 'alice', key: 'yearofbirth', value: 'alice-yearofbirth' },
                     { username: 'bob', key: 'country', value: 'bob-country' },
                     { username: 'bob', key: 'yearofbirth', value: 'bob-yearofbirth' },
-                    { username: 'n0b0dy', key: 'country' },
-                    { username: 'n0b0dy', key: 'yearofbirth' },
+                    { username: 'n0b0dy', key: 'country', value: null },
+                    { username: 'n0b0dy', key: 'yearofbirth', value: null },
                     { username: 'alice', key: 'key1', value: 'alice-key1' },
                     { username: 'alice', key: 'key2', value: 'alice-key2' },
                     { username: 'bob', key: 'key1', value: 'bob-key1' },
                     { username: 'bob', key: 'key2', value: 'bob-key2' },
-                    { username: 'n0b0dy', key: 'key1' },
-                    { username: 'n0b0dy', key: 'key2' }
+                    { username: 'n0b0dy', key: 'key1', value: null},
+                    { username: 'n0b0dy', key: 'key2', value: null }
                 ]);
                 done();
             });

--- a/tests/test-users-api.ts
+++ b/tests/test-users-api.ts
@@ -45,7 +45,17 @@ const data = {
   tokens: [{
     createAccountKey: 'valid',
     token: VALID_AUTH_TOKEN
-  }]
+  }],
+  accounts: {
+    jeko: {
+      id: "jeko",
+      aliases: {
+        name: "jeko-name",
+        tag: "jeko-tag",
+        email: "jeko@fovea.cc"
+      }
+    }
+  }
 };
 const apiSecret = process.env.API_SECRET;
 
@@ -80,7 +90,11 @@ const baseTest = function() {
   td.when(directoryClient.byAlias(
     td.matchers.contains({type: "tag"}),
     td.matchers.isA(Function)))
-      .thenDo((alias, cb) => cb(null, {id: alias.value}));
+    .thenDo((alias, cb) => cb(null, { id: alias.value }));
+
+  td.when(directoryClient.byId(
+    td.matchers.contains({ id: data.accounts.jeko.id }), td.callback))
+    .thenCallback(null, data.accounts.jeko);
 
   const callback = td.function('callback');
   const authdbClient = fakeAuthdb.createClient();
@@ -218,10 +232,15 @@ describe('users-api', function() {
           expect(res.body).to.eql({
             username,
             metadata: {
+              '$blocked': null,
+              location: null,
+              singleplayerstats: null,
+              name: "jeko-name",
               country: null,
               yearofbirth: null,
               '$chatdisabled': null,
-            }});
+            }
+          });
           return done();
       });
     }));


### PR DESCRIPTION
I used the usermetaRouter .getBulkForUser method.
```
const keys: string[] = ['country', 'yearofbirth', '$chatdisabled', '$blocked', 'location',
            'singleplayerstats', 'name'];
        options.rootUsermetaClient.getBulkForUser(params, keys, (err2, reply2) => {
```
since the bulk-usermeta is well tested before, I am not sure If i need to add more tests here.
I just adjusted the test and add test the returned metadata as per the defined keys.
Closes #75 